### PR TITLE
Add customizable variable for temp file location.

### DIFF
--- a/flymake-phpcs.el
+++ b/flymake-phpcs.el
@@ -84,6 +84,13 @@
   :type 'string
   :group 'flymake-phpcs)
 
+(defcustom flymake-phpcs-location 'inplace
+  "Where to create the temporary copy: one of 'tempdir or 'inplace (default)."
+  :type `(choice
+          (const :tag "In place" inplace)
+          (const :tag "Temporary location" tempdir))
+  :group 'flymake-phpcs)
+
 (defun flymake-phpcs-command (filename)
   "Construct a command that flymake can use to check PHP source."
   (list "phpcs" "--report=csv"
@@ -99,7 +106,7 @@
   (interactive)
   (flymake-easy-load 'flymake-phpcs-command
                      flymake-phpcs-err-line-patterns
-                     'tempdir
+                     flymake-phpcs-location
                      "php"))
 
 (provide 'flymake-phpcs)


### PR DESCRIPTION
Also flipped the default to `'inplace`.

I flipped the default because my experience is that inplace generally works better.

I.e. on Mac OS X `temporary-file-directory` is located beneath /var and /var is a sym link to /private/var. Flymake can have problems with sym links.

Some code sniffer sniffs also fails when running on a file in `'tempdir` because the will look for other files in the same directory.
